### PR TITLE
Enable absolute paths in filename patterns

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -301,7 +301,7 @@ function expand_filename_patterns(patterns)
     if startswith(pattern, '/') && !Sys.iswindows()
       # Glob.glob does not support absolute paths; this workaround should enable this at least on
       # non-Windows platforms
-      append!(filenames, glob(lstrip(pattern, '/')), "/")
+      append!(filenames, glob(lstrip(pattern, '/'), "/"))
     else
       append!(filenames, glob(pattern))
     end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -39,16 +39,7 @@ function trixi2vtk(filename::AbstractString...;
   if isempty(filename)
     error("no input file was provided")
   end
-  filenames = String[]
-  for pattern in filename
-    if startswith(pattern, '/') && !Sys.iswindows()
-      # Glob.glob does not support absolute paths; this workaround should enable this at least on
-      # non-Windows platforms
-      append!(filenames, glob(lstrip(pattern, '/')), "/")
-    else
-      append!(filenames, glob(pattern))
-    end
-  end
+  filenames = expand_filename_patterns(filename)
   if isempty(filenames)
     error("no such file(s): ", join(filename, ", "))
   end
@@ -300,4 +291,21 @@ function add_celldata!(vtk_celldata, mesh::TreeMesh, verbose)
   end
 
   return vtk_celldata
+end
+
+
+function expand_filename_patterns(patterns)
+  filenames = String[]
+
+  for pattern in patterns
+    if startswith(pattern, '/') && !Sys.iswindows()
+      # Glob.glob does not support absolute paths; this workaround should enable this at least on
+      # non-Windows platforms
+      append!(filenames, glob(lstrip(pattern, '/')), "/")
+    else
+      append!(filenames, glob(pattern))
+    end
+  end
+
+  return filenames
 end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -298,10 +298,9 @@ function expand_filename_patterns(patterns)
   filenames = String[]
 
   for pattern in patterns
-    if startswith(pattern, '/') && !Sys.iswindows()
-      # Glob.glob does not support absolute paths; this workaround should enable this at least on
-      # non-Windows platforms
-      append!(filenames, glob(lstrip(pattern, '/'), "/"))
+    if startswith(pattern, '/')
+      # Glob.glob does not support absolute paths
+      append!(filenames, glob(relpath(pattern)))
     else
       append!(filenames, glob(pattern))
     end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -41,7 +41,13 @@ function trixi2vtk(filename::AbstractString...;
   end
   filenames = String[]
   for pattern in filename
-    append!(filenames, glob(pattern))
+    if startswith(pattern, '/') && !Sys.iswindows()
+      # Glob.glob does not support absolute paths; this workaround should enable this at least on
+      # non-Windows platforms
+      append!(filenames, glob(lstrip(pattern, '/')), "/")
+    else
+      append!(filenames, glob(pattern))
+    end
   end
   if isempty(filenames)
     error("no such file(s): ", join(filename, ", "))

--- a/test/test_manual.jl
+++ b/test/test_manual.jl
@@ -45,7 +45,7 @@ isdir(outdir) && rm(outdir, recursive=true)
   end
 
   @timed_testset "expand_filename_patterns" begin
-    @test expand_filename_patterns(["/*"]) isa Vector{String}
+    @test Trixi2Vtk.expand_filename_patterns(["/*"]) isa Vector{String}
   end
 end
 

--- a/test/test_manual.jl
+++ b/test/test_manual.jl
@@ -43,6 +43,10 @@ isdir(outdir) && rm(outdir, recursive=true)
     @test Trixi2Vtk.pvd_filenames("", "manual", "out") == (joinpath("out", "manual"), joinpath("out", "manual_celldata"))
     @test_throws ErrorException Trixi2Vtk.pvd_filenames(("a", "b"), nothing, "out")
   end
+
+  @timed_testset "expand_filename_patterns" begin
+    @test expand_filename_patterns(["/*"]) isa Vector{String}
+  end
 end
 
 # Clean up afterwards: delete Trixi output directory

--- a/test/test_manual.jl
+++ b/test/test_manual.jl
@@ -46,8 +46,8 @@ isdir(outdir) && rm(outdir, recursive=true)
 
   @timed_testset "expand_filename_patterns" begin
     mktemp() do path, _
-      patterns = [joinpath(dirname(path), "*")]
-      expanded = Trixi2Vtk.expand_filename_patterns(patterns)
+      # Test that absolute filepaths work
+      expanded = Trixi2Vtk.expand_filename_patterns([path])
       @test basename(expanded[1]) == basename(path)
     end
   end

--- a/test/test_manual.jl
+++ b/test/test_manual.jl
@@ -45,7 +45,11 @@ isdir(outdir) && rm(outdir, recursive=true)
   end
 
   @timed_testset "expand_filename_patterns" begin
-    @test Trixi2Vtk.expand_filename_patterns(["/*"]) isa Vector{String}
+    mktemp() do path, _
+      patterns = [joinpath(dirname(path), "*")]
+      expanded = Trixi2Vtk.expand_filename_patterns(patterns)
+      @test basename(expanded[1]) == basename(path)
+    end
   end
 end
 


### PR DESCRIPTION
Allows absolute filename patterns in first argument to `trixi2vtk`. Original issue was reported by @OsKnoth.