### PR TITLE
update compat bounds for HDF5.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
 Glob = "1.3"
-HDF5 = "0.14, 0.15"
+HDF5 = "0.14, 0.15, 0.16"
 ProgressMeter = "1.3"
 StaticArrays = "0.12, 1.0"
 TimerOutputs = "0.5"

--- a/src/vtktools.jl
+++ b/src/vtktools.jl
@@ -71,9 +71,9 @@ function build_vtk_grids(::Val{:vti}, mesh, n_visnodes, verbose,
     Nx = Ny = resolution + 1
     dx = dy = length_level_0/resolution
     origin = center_level_0 .- 1/2 * length_level_0
-    spacing = [dx, dy]
+    spacing = (dx, dy)
     @timeit "build VTK grid (node data)" vtk_nodedata = vtk_grid(vtk_filename, Nx, Ny,
-                                                        origin=origin,
+                                                        origin=tuple(origin...),
                                                         spacing=spacing)
   else
     vtk_nodedata = nothing


### PR DESCRIPTION
CI shows that https://github.com/jipolanco/WriteVTK.jl/commit/4119c8ba91b9fd5cb845b316046a03389143f15e broke our stuff since we pass an `SVector` instead of an `NTuple` as keyword argument `origin` to `vtk_grid`...