### PR TITLE
introduce `get_default_nvisnodes_mesh`

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -115,7 +115,7 @@ function trixi2vtk(filename::AbstractString...;
       n_visnodes = get_default_nvisnodes_solution(nvisnodes, n_nodes, mesh)
     else
       # If file is a mesh file, do not interpolate data as detailed
-      n_visnodes = get_default_nvisnodes_mesh(nvisnodes, n_nodes, mesh)
+      n_visnodes = get_default_nvisnodes_mesh(nvisnodes, mesh)
     end
 
     # Create output directory if it does not exist
@@ -272,24 +272,20 @@ end
 
 
 # default number of visualization nodes if only the mesh should be visualized
-function get_default_nvisnodes_mesh(nvisnodes, n_nodes, mesh::TreeMesh)
+function get_default_nvisnodes_mesh(nvisnodes, mesh::TreeMesh)
   if nvisnodes === nothing
-    # for a mesh file, we do not need to interpolate
+    # for a Cartesian mesh, we do not need to interpolate
     return 1
-  elseif nvisnodes == 0
-    return n_nodes
   else
     return nvisnodes
   end
 end
 
-function get_default_nvisnodes_mesh(nvisnodes, n_nodes,
+function get_default_nvisnodes_mesh(nvisnodes,
                                     mesh::Union{StructuredMesh, UnstructuredMesh2D, P4estMesh})
   if nvisnodes === nothing
     # for curved meshes, we need to get at least the vertices
     return 2
-  elseif nvisnodes == 0
-    return n_nodes
   else
     return nvisnodes
   end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -112,10 +112,10 @@ function trixi2vtk(filename::AbstractString...;
       assert_cells_elements(n_elements, mesh, filename, meshfile)
 
       # Determine resolution for data interpolation
-      n_visnodes = get_default_nvisnodes(nvisnodes, n_nodes, mesh)
+      n_visnodes = get_default_nvisnodes_solution(nvisnodes, n_nodes, mesh)
     else
-      # If file is a mesh file, do not interpolate data
-      n_visnodes = 1
+      # If file is a mesh file, do not interpolate data as detailed
+      n_visnodes = get_default_nvisnodes_mesh(nvisnodes, n_nodes, mesh)
     end
 
     # Create output directory if it does not exist
@@ -250,7 +250,8 @@ function assert_cells_elements(n_elements, mesh::P4estMesh, filename, meshfile)
 end
 
 
-function get_default_nvisnodes(nvisnodes, n_nodes, mesh::TreeMesh)
+# default number of visualization nodes if a solution should be visualized
+function get_default_nvisnodes_solution(nvisnodes, n_nodes, mesh::TreeMesh)
   if nvisnodes === nothing
     return 2 * n_nodes
   elseif nvisnodes == 0
@@ -260,10 +261,34 @@ function get_default_nvisnodes(nvisnodes, n_nodes, mesh::TreeMesh)
   end
 end
 
-
-function get_default_nvisnodes(nvisnodes, n_nodes,
-                               mesh::Union{StructuredMesh, UnstructuredMesh2D, P4estMesh})
+function get_default_nvisnodes_solution(nvisnodes, n_nodes,
+                                        mesh::Union{StructuredMesh, UnstructuredMesh2D, P4estMesh})
   if nvisnodes === nothing || nvisnodes == 0
+    return n_nodes
+  else
+    return nvisnodes
+  end
+end
+
+
+# default number of visualization nodes if only the mesh should be visualized
+function get_default_nvisnodes_mesh(nvisnodes, n_nodes, mesh::TreeMesh)
+  if nvisnodes === nothing
+    # for a mesh file, we do not need to interpolate
+    return 1
+  elseif nvisnodes == 0
+    return n_nodes
+  else
+    return nvisnodes
+  end
+end
+
+function get_default_nvisnodes_mesh(nvisnodes, n_nodes,
+                                    mesh::Union{StructuredMesh, UnstructuredMesh2D, P4estMesh})
+  if nvisnodes === nothing
+    # for curved meshes, we need to get at least the vertices
+    return 2
+  elseif nvisnodes == 0
     return n_nodes
   else
     return nvisnodes

--- a/test/test_2d.jl
+++ b/test/test_2d.jl
@@ -38,6 +38,7 @@ end
         outfiles = ("solution_000000.vtu", "solution_000000_celldata.vtu",
                     "solution_00000.pvd", "solution_00000_celldata.pvd")
       end
+      @test_nowarn trixi2vtk("mesh.h5")
 
       # Store output files as artifacts to facilitate debugging of failing tests
       testname = "2d-tree-mesh-uniform-mesh"
@@ -86,6 +87,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
             hashes=[("solution_000000.vtu", "564701ed0a9a90230f3a67f8bddd0616c818319b")])
       end
+      @test_nowarn trixi2vtk("mesh.h5")
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)
@@ -133,6 +135,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
             hashes=[("solution_000000.vtu", "acc03f295d2b7daee2cb0b4e29b90035c5e92bd7")])
       end
+      @test_nowarn trixi2vtk("mesh.h5")
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)
@@ -159,6 +162,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
           hashes=[("solution_000000.vtu", "a80aadb353ce6ec40baa1b94d278c480f17d0419")])
       end
+      @test_nowarn trixi2vtk("mesh.h5")
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)

--- a/test/test_2d.jl
+++ b/test/test_2d.jl
@@ -38,7 +38,7 @@ end
         outfiles = ("solution_000000.vtu", "solution_000000_celldata.vtu",
                     "solution_00000.pvd", "solution_00000_celldata.pvd")
       end
-      @test_nowarn trixi2vtk("mesh.h5")
+      @test_nowarn trixi2vtk(joinpath(outdir, "mesh.h5"))
 
       # Store output files as artifacts to facilitate debugging of failing tests
       testname = "2d-tree-mesh-uniform-mesh"
@@ -87,7 +87,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
             hashes=[("solution_000000.vtu", "564701ed0a9a90230f3a67f8bddd0616c818319b")])
       end
-      @test_nowarn trixi2vtk("mesh.h5")
+      @test_nowarn trixi2vtk(joinpath(outdir, "mesh.h5"))
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)
@@ -135,7 +135,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
             hashes=[("solution_000000.vtu", "acc03f295d2b7daee2cb0b4e29b90035c5e92bd7")])
       end
-      @test_nowarn trixi2vtk("mesh.h5")
+      @test_nowarn trixi2vtk(joinpath(outdir, "mesh.h5"))
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)
@@ -162,7 +162,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
           hashes=[("solution_000000.vtu", "a80aadb353ce6ec40baa1b94d278c480f17d0419")])
       end
-      @test_nowarn trixi2vtk("mesh.h5")
+      @test_nowarn trixi2vtk(joinpath(outdir, "mesh.h5"))
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)

--- a/test/test_3d.jl
+++ b/test/test_3d.jl
@@ -25,7 +25,7 @@ end
       test_trixi2vtk("solution_000000.h5", outdir,
           hashes=[("solution_000000.vtu", "6ab3aa525851187ee0839e1d670a254a66be4ad7"),
                   ("solution_000000_celldata.vtu", "fdfee2d4200ecdad08067b37908412813016f4e7")])
-      @test_nowarn trixi2vtk("mesh.h5")
+      @test_nowarn trixi2vtk(joinpath(outdir, "mesh.h5"))
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu", "solution_000000_celldata.vtu")
@@ -52,7 +52,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
             hashes=[("solution_000000.vtu", "58e07f981fd6c005ea17e47054bd509c2c66d771")])
       end
-      @test_nowarn trixi2vtk("mesh.h5")
+      @test_nowarn trixi2vtk(joinpath(outdir, "mesh.h5"))
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)
@@ -79,7 +79,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
           hashes=[("solution_000000.vtu", "0fa5a099378d153aa3a1bb7dcf3559ea5d6bf9c5")])
       end
-      @test_nowarn trixi2vtk("mesh.h5")
+      @test_nowarn trixi2vtk(joinpath(outdir, "mesh.h5"))
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)

--- a/test/test_3d.jl
+++ b/test/test_3d.jl
@@ -25,6 +25,7 @@ end
       test_trixi2vtk("solution_000000.h5", outdir,
           hashes=[("solution_000000.vtu", "6ab3aa525851187ee0839e1d670a254a66be4ad7"),
                   ("solution_000000_celldata.vtu", "fdfee2d4200ecdad08067b37908412813016f4e7")])
+      @test_nowarn trixi2vtk("mesh.h5")
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu", "solution_000000_celldata.vtu")
@@ -51,6 +52,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
             hashes=[("solution_000000.vtu", "58e07f981fd6c005ea17e47054bd509c2c66d771")])
       end
+      @test_nowarn trixi2vtk("mesh.h5")
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)
@@ -77,6 +79,7 @@ end
         test_trixi2vtk("solution_000000.h5", outdir,
           hashes=[("solution_000000.vtu", "0fa5a099378d153aa3a1bb7dcf3559ea5d6bf9c5")])
       end
+      @test_nowarn trixi2vtk("mesh.h5")
 
       # Store output files as artifacts to facilitate debugging of failing tests
       outfiles = ("solution_000000.vtu",)


### PR DESCRIPTION
This should hopefully fix the issue reported in #55. The idea is to still use `nvisnodes` even when visualizing only a mesh file by introducing another function `get_default_nvisnodes_mesh` and renaming the previous `get_default_nvisnodes` to `get_default_nvisnodes_solution`.