### PR TITLE
update CI to Julia v1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
+          - '1.9'
           # - 'nightly'
         os:
           - ubuntu-latest
@@ -41,6 +41,10 @@ jobs:
           - windows-latest
         arch:
           - x64
+        include:
+          - version: '1.7'
+            os: ubuntu-latest
+            arch: x64
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
I updated CI to use Julia v1.9 (same as in Trixi.jl) to allow using the latest version of Trixi.jl (requiring Julia v1.8). I added one additional job to make sure everything still works with Julia v1.7 and updated the required CI tests accordingly. This should allow testing HDF5.jl v0.17 in #69. 