### PR TITLE
Update commit hash to reference files

### DIFF
--- a/test/test_trixi2vtk.jl
+++ b/test/test_trixi2vtk.jl
@@ -38,7 +38,7 @@ end
 # Note: The purpose of using a specific commit hash (instead of `main`) is to be able to tie a given
 #       version of Trixi2Vtk to a specific version of the test file repository. This way, also tests
 #       for older Trixi2Vtk releases should continue to work.
-const TEST_REFERENCE_COMMIT = "c0a966b06489f9b2ee3aefeb0a5c0dae733df36f"
+const TEST_REFERENCE_COMMIT = "86a43fe8dc254130345754fb512268204cf2233c"
 
 # Local folder to store downloaded reference files. If you change this, also adapt `../.gitignore`!
 const TEST_REFERENCE_DIR = "reference_files"


### PR DESCRIPTION
The fixed wave speed computation in https://github.com/trixi-framework/Trixi.jl/pull/1898 requires a update of the reference files used for testing https://github.com/trixi-framework/Trixi2Vtk_reference_files/pull/1.

This should lead to some failing tests until the wave speed computation in https://github.com/trixi-framework/Trixi.jl/pull/1898 is merged.