### PR TITLE
fix reference commit for old versions of Julia/Trixi.jl

### DIFF
--- a/test/test_trixi2vtk.jl
+++ b/test/test_trixi2vtk.jl
@@ -38,7 +38,11 @@ end
 # Note: The purpose of using a specific commit hash (instead of `main`) is to be able to tie a given
 #       version of Trixi2Vtk to a specific version of the test file repository. This way, also tests
 #       for older Trixi2Vtk releases should continue to work.
-const TEST_REFERENCE_COMMIT = "86a43fe8dc254130345754fb512268204cf2233c"
+if VERSION < v"1.8"
+  const TEST_REFERENCE_COMMIT = "c0a966b06489f9b2ee3aefeb0a5c0dae733df36f"
+else
+  const TEST_REFERENCE_COMMIT = "86a43fe8dc254130345754fb512268204cf2233c"
+end
 
 # Local folder to store downloaded reference files. If you change this, also adapt `../.gitignore`!
 const TEST_REFERENCE_DIR = "reference_files"


### PR DESCRIPTION
The current version of Trixi.jl requires Julia v1.8. Thus, we need to use the old reference commit for tests on Julia v1.7. Xref https://github.com/trixi-framework/Trixi2Vtk.jl/pull/90