### PR TITLE
Update reference commit for new rotor files

### DIFF
--- a/test/test_trixi2vtk.jl
+++ b/test/test_trixi2vtk.jl
@@ -56,7 +56,7 @@ end
 if VERSION < v"1.8"
   const TEST_REFERENCE_COMMIT = "c0a966b06489f9b2ee3aefeb0a5c0dae733df36f"
 else
-  const TEST_REFERENCE_COMMIT = "86a43fe8dc254130345754fb512268204cf2233c"
+  const TEST_REFERENCE_COMMIT = "e51f3613ac1adfcfd2bf1d74a2756034dab0579c"
 end
 
 # Local folder to store downloaded reference files. If you change this, also adapt `../.gitignore`!


### PR DESCRIPTION
This should fix the broken downstream tests caused by updating the nonconservative terms + mortars in https://github.com/trixi-framework/Trixi.jl/pull/2134. We need to wait for the Trixi PR to merge first and then merge this.