### PR TITLE
Allow nvisnodes = 1

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -146,7 +146,11 @@ function trixi2vtk(filename::AbstractString...;
       if (reinterpolate && !data_is_uniform) || (!reinterpolate && data_is_uniform)
         # (1) Default settings; presumably the most common
         # (2) Finite difference data
-        node_set = collect(range(-1, 1, length=n_visnodes))
+        if n_visnodes == 1
+          node_set = [0.0]
+        else
+          node_set = collect(range(-1, 1, length=n_visnodes))
+        end
       elseif !reinterpolate && !data_is_uniform
         # raw data is on a set of LGL nodes
         node_set, _ = gauss_lobatto_nodes_weights(n_visnodes)

--- a/test/test_manual.jl
+++ b/test/test_manual.jl
@@ -42,6 +42,8 @@ isdir(outdir) && rm(outdir, recursive=true)
   @testset "trixi2vtk set number of output nodes" begin
     @test_nowarn trixi2vtk(joinpath(outdir, "solution_" * LEADING_ZEROS * "000000.h5"); nvisnodes=0)
 
+    @test_nowarn trixi2vtk(joinpath(outdir, "solution_" * LEADING_ZEROS * "000000.h5"); nvisnodes=1)
+
     @test_nowarn trixi2vtk(joinpath(outdir, "solution_" * LEADING_ZEROS * "000000.h5"); nvisnodes=5)
   end
 


### PR DESCRIPTION
Currently, trixi2vtk gives an error when I try to pass nvisnodes = 1. This PR tries to fix it. The nvisnodes = 1 is a useful option in TreeMesh as it allows us to visualize adaptively refined elements (and not solution points).

A visualization with initial refinement level = 2  and nvisnodes = 1 can be found below:
<img width="620" alt="Screenshot 2025-03-21 at 7 18 55 PM" src="https://github.com/user-attachments/assets/b38a99b2-037c-4176-b4c4-b236b9deb054" />
