### PR TITLE
Revert workaround related to Coveralls on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,6 @@ jobs:
         env:
           PYTHON: ""
       - uses: julia-actions/julia-processcoverage@v1
-      # Workaround for https://github.com/coverallsapp/github-action/issues/264
-      - name: Trust Coveralls Homebrew tap (Homebrew 6 requirement)
-        if: runner.os == 'macOS'
-        run: brew trust coverallsapp/coveralls
       - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Revert the workaround introduced in #142 since the underlying issue has been resolved in the coveralls GitHub action.